### PR TITLE
WIP - Homepage cms

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,0 +1,4 @@
+---
+title: Sunrise Bay Area
+bannerWelcome: Welcome to the Bay Area Hub of the Sunrise Movement
+---

--- a/content/_index.md
+++ b/content/_index.md
@@ -1,4 +1,0 @@
----
-title: Sunrise Bay Area
-bannerWelcome: Welcome to the Bay Area Hub of the Sunrise Movement
----

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -6,7 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta name="description" content="">
 
-  <title>Sunrise Bay Area</title>
+  <title>{{.Title}}</title>
 
   <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
 
@@ -21,18 +21,15 @@
   <!-- Header -->
   <div class="header masthead" id="header">
     <div class="container">
-      <h1 id="title-text"><span>Welcome to the Bay Area Hub of the Sunrise Movement</span></h1>
+      <h1 id="title-text"><span>{{.Params.bannerWelcome}}</span></h1>
     </div>
   </div>
 
 
   <!-- Who We Are -->
-  <div class="section" id="who-we-are">
+  <section class="section" id="who-we-are">
     <div class="container">
-      <h2>Who We Are</h2>
-      <p>Sunrise is a national movement to stop climate change and create millions of good jobs in the process. Sunrise Bay Area is one of the many local hubs that have sprung up nationwide to bring that movement to life! </p>
-
-      <p>We're building an army of young people to make climate change an urgent priority across America, end the corrupting influence of fossil fuel executives on our politics, and elect leaders who stand up for the health and wellbeing of all people. </p>
+      {{ .Params.section1}}
 
       <p class="center"><a href="https://docs.google.com/document/d/1ayVhE6cH76tCCW2kfI9MnD8T58In9te1XHk4L-0q9-Q/" target="_blank">Learn More About the Movement</a></p>
       <p class="center"><a href="https://www.congress.gov/116/bills/hres109/BILLS-116hres109ih.pdf" target="_blank">Read the Green New Deal Resolution</a></p>
@@ -40,23 +37,18 @@
       <div class="video-container"><iframe src="https://player.vimeo.com/video/387877356" width="640" height="360" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
         <p><a href="https://vimeo.com/387877356">Generation Green New Deal sneak peak [Spanish subtitles]</a> from <a href="https://vimeo.com/sameilertsen">Sam Eilertsen</a> on <a href="https://vimeo.com">Vimeo</a>.</p></div>
     </div>
-  </div>
+  </section>
 
-  <div class="section" id="what-we-do">
+  <section class="section" id="what-we-do">
     <div class="container">
-      <h2>What We Do</h2>
-      <h3>And How You Can, Too!</h3>
-
-      <p>We’re making the climate crisis a decisive issue in the 2020 election by mobilizing millions, turning up the heat, and forcing the media to tell our story: our future is at stake, and we demand a real plan for addressing the climate crisis. </p>
-
-      <p>As a local hub, Sunrise Bay Area is one of many in-person communities making this movement real. We organize strikes, pressure local politicians, make art, host trainings, throw parties, and more!</p>
+      {{ .Params.section2 }}
 
       <p class="center"><a href="https://bit.ly/sunrisenewmembersurvey" target="_blank">Connect with our Welcoming Crew and Get Plugged In!</a></p>
       <p class="center"><a href="https://secure.actblue.com/donate/sunrisebayarea" target="_blank">Donate to our Equity Fund</a></p>
       <p class="center"><a href="bit.ly/feb23sunriseOT" target="_blank">Sign up for our Orientation Training on Feb. 23rd</a></p>
 
     </div>
-  </div>
+  </section>
 
   <!-- Footer -->
   <div class="footer center">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -29,10 +29,7 @@
   <!-- Who We Are -->
   <section class="section" id="who-we-are">
     <div class="container">
-      {{ .Params.section1}}
-
-      <p class="center"><a href="https://docs.google.com/document/d/1ayVhE6cH76tCCW2kfI9MnD8T58In9te1XHk4L-0q9-Q/" target="_blank">Learn More About the Movement</a></p>
-      <p class="center"><a href="https://www.congress.gov/116/bills/hres109/BILLS-116hres109ih.pdf" target="_blank">Read the Green New Deal Resolution</a></p>
+      {{ .Params.section1 | markdownify }}
 
       <div class="video-container"><iframe src="https://player.vimeo.com/video/387877356" width="640" height="360" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
         <p><a href="https://vimeo.com/387877356">Generation Green New Deal sneak peak [Spanish subtitles]</a> from <a href="https://vimeo.com/sameilertsen">Sam Eilertsen</a> on <a href="https://vimeo.com">Vimeo</a>.</p></div>
@@ -41,12 +38,7 @@
 
   <section class="section" id="what-we-do">
     <div class="container">
-      {{ .Params.section2 }}
-
-      <p class="center"><a href="https://bit.ly/sunrisenewmembersurvey" target="_blank">Connect with our Welcoming Crew and Get Plugged In!</a></p>
-      <p class="center"><a href="https://secure.actblue.com/donate/sunrisebayarea" target="_blank">Donate to our Equity Fund</a></p>
-      <p class="center"><a href="bit.ly/feb23sunriseOT" target="_blank">Sign up for our Orientation Training on Feb. 23rd</a></p>
-
+      {{ .Params.section2 | markdownify }}
     </div>
   </section>
 

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -7,7 +7,7 @@ backend:
 media_folder: static/img
 public_folder: /img
 collections:
-  - label: "About Page"
+  - label: "Index Page"
     name: "index"
     file: "content/_index.md"
     fields:

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,12 +1,20 @@
 backend:
   name: github
   repo: sunrise-bay-area/sunrise-bay-area
-  branch: master
+  branch: homepage-cms
   base_url: https://us-central1-sunrise-bay-area-website.cloudfunctions.net
   auth_endpoint: /oauth/auth
 media_folder: static/img
 public_folder: /img
 collections:
+  - label: "About Page"
+    name: "index"
+    file: "content/_index.md"
+    fields:
+      - {label: Title, name: title, widget: string}
+      - {label: Banner Welcome, name: bannerWelcome, widget: string}
+      - {label: Section 1, name: section1, widget: markdown}
+      - {label: Section 2, name: section2, widget: markdown}
   - name: 'blog'
     label: 'Blog'
     folder: 'content/blog'

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,20 +1,23 @@
 backend:
   name: github
   repo: sunrise-bay-area/sunrise-bay-area
-  branch: homepage-cms
+  branch: master
   base_url: https://us-central1-sunrise-bay-area-website.cloudfunctions.net
   auth_endpoint: /oauth/auth
 media_folder: static/img
 public_folder: /img
 collections:
-  - label: "Index Page"
-    name: "index"
-    file: "content/_index.md"
-    fields:
-      - {label: Title, name: title, widget: string}
-      - {label: Banner Welcome, name: bannerWelcome, widget: string}
-      - {label: Section 1, name: section1, widget: markdown}
-      - {label: Section 2, name: section2, widget: markdown}
+  - label: "Pages"
+    name: "pages"
+    files:
+    - label: "Index Page"
+      name: "index"
+      file: "content/_index.md"
+      fields:
+        - {label: Title, name: title, widget: string}
+        - {label: Banner Welcome, name: bannerWelcome, widget: string}
+        - {label: Section 1, name: section1, widget: markdown}
+        - {label: Section 2, name: section2, widget: markdown}
   - name: 'blog'
     label: 'Blog'
     folder: 'content/blog'


### PR DESCRIPTION
Addresses https://github.com/sunrise-bay-area/sunrise-bay-area/issues/7

This is a spike on pulling some homepage content from Netlify CMS. It isn't ready for merge but could use a preliminary review.

It currently disrupts a little bit of text and styling from the current sfbay.sunrisemovement.org, so we should not yet merge.

## Questions for reviewer:
- Do we want sections like the GND video to be managed by the CMS as well?
- Currently confused about what we are promoting as our "official" site - is it still https://sunrisebayarea.org/ since that has the newer design? (In which case - not sure if parity with current sfbay.sunrisemovement.org currently matters, since it isn't "live")

## Screenshots

<img width="1322" alt="Screen Shot 2020-03-09 at 5 34 20 PM" src="https://user-images.githubusercontent.com/13489089/76268730-3c6bc400-622c-11ea-8152-45873506ba16.png">

<img width="1384" alt="Screen Shot 2020-03-09 at 5 37 02 PM" src="https://user-images.githubusercontent.com/13489089/76268814-9b313d80-622c-11ea-9867-3d927ec06139.png">
Note: banner text reflects what is currently on https://sunrisebayarea.org/, not https://sfbay.sunrisemovement.org/

Note: links are not aligned like they used to be, but I'm uncertain if this page is actually live yet / if it matters
