### PR TITLE
Created Earthday Redirect

### DIFF
--- a/static/earthweek/index.html
+++ b/static/earthweek/index.html
@@ -1,0 +1,1 @@
+<head><meta http-equiv="Refresh" content="0; URL=https://www.sbaearthday.com/"></head>


### PR DESCRIPTION
After this is merged and deployed, when a user visits sfbay.sunrisemovement.org/earthweek, they will be redirected to [sbaearthday.com](https://www.sbaearthday.com/).

This helps address #60.